### PR TITLE
Adding dependency on Spotless for linting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,21 @@
+name: Pull Request
+on:
+  pull_request:
+    types: [ 'opened', 'synchronize' ]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+          cache: gradle
+      - run: ./gradlew spotlessKotlinCheck
+        with:
+          report-path: build/reports/*.xml # Support glob patterns by https://www.npmjs.com/package/@actions/glob
+        continue-on-error: false # If annotations contain error of severity, action-android-lint exit 1.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,4 +18,4 @@ jobs:
       - run: ./gradlew spotlessKotlinCheck
         with:
           report-path: build/reports/*.xml # Support glob patterns by https://www.npmjs.com/package/@actions/glob
-        continue-on-error: false # If annotations contain error of severity, action-android-lint exit 1.
+          continue-on-error: false # If annotations contain error of severity, action-android-lint exit 1.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,6 @@ jobs:
           distribution: zulu
           java-version: 11
           cache: gradle
-      - run: ./gradlew spotlessKotlinCheck
-        with:
           report-path: build/reports/*.xml # Support glob patterns by https://www.npmjs.com/package/@actions/glob
           continue-on-error: false # If annotations contain error of severity, action-android-lint exit 1.
+      - run: ./gradlew spotlessKotlinCheck

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@ plugins {
     id("org.jetbrains.changelog") version "1.3.1"
     // Gradle Qodana Plugin
     id("org.jetbrains.qodana") version "0.1.13"
+    // Formatting
+    id("com.diffplug.spotless") version "6.3.0"
 }
 
 group = properties("pluginGroup")
@@ -46,6 +48,12 @@ qodana {
     reportPath.set(projectDir.resolve("build/reports/inspections").canonicalPath)
     saveReport.set(true)
     showReport.set(System.getenv("QODANA_SHOW_REPORT")?.toBoolean() ?: false)
+}
+
+spotless {
+    kotlin {
+        ktfmt("0.32").kotlinlangStyle()
+    }
 }
 
 tasks {

--- a/src/main/kotlin/com/github/jyoo980/reachhover/MyBundle.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/MyBundle.kt
@@ -4,8 +4,7 @@ import com.intellij.DynamicBundle
 import org.jetbrains.annotations.NonNls
 import org.jetbrains.annotations.PropertyKey
 
-@NonNls
-private const val BUNDLE = "messages.MyBundle"
+@NonNls private const val BUNDLE = "messages.MyBundle"
 
 object MyBundle : DynamicBundle(BUNDLE) {
 

--- a/src/main/kotlin/com/github/jyoo980/reachhover/listeners/MyProjectManagerListener.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/listeners/MyProjectManagerListener.kt
@@ -1,9 +1,9 @@
 package com.github.jyoo980.reachhover.listeners
 
+import com.github.jyoo980.reachhover.services.MyProjectService
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
-import com.github.jyoo980.reachhover.services.MyProjectService
 
 internal class MyProjectManagerListener : ProjectManagerListener {
 

--- a/src/main/kotlin/com/github/jyoo980/reachhover/services/MyProjectService.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/services/MyProjectService.kt
@@ -1,7 +1,7 @@
 package com.github.jyoo980.reachhover.services
 
-import com.intellij.openapi.project.Project
 import com.github.jyoo980.reachhover.MyBundle
+import com.intellij.openapi.project.Project
 
 class MyProjectService(project: Project) {
 


### PR DESCRIPTION
This (in theory) should run every time a PR is opened/new commit is pushed to a PR, and block merging until linting passes.