### PR TITLE
Adding base implementation of an EditorHover listener

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,8 @@ intellij {
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
     plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+    // This enables access to the Java PSI.
+    plugins.set(listOf("com.intellij.java"))
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin

--- a/src/main/kotlin/com/github/jyoo980/reachhover/listeners/EditorHoverListener.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/listeners/EditorHoverListener.kt
@@ -1,0 +1,19 @@
+package com.github.jyoo980.reachhover.listeners
+
+import com.github.jyoo980.reachhover.util.MouseHoverUtil
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseMotionListener
+
+internal class EditorHoverListener : EditorMouseMotionListener {
+
+    private val logger: Logger = Logger.getInstance(EditorHoverListener::class.java)
+
+    override fun mouseMoved(e: EditorMouseEvent) {
+        val offset = MouseHoverUtil.targetOffset(e) ?: return
+        val project = e.editor.project ?: return
+        val optElement = MouseHoverUtil.elementAtOffset(project, e.editor, offset)
+        // TODO: 2022-02-17 Add check whether optElement is the item we're looking for
+        // (variable/method arg).
+    }
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/MouseHoverUtil.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/MouseHoverUtil.kt
@@ -38,7 +38,7 @@ object MouseHoverUtil {
                 element = it.findElementAt(offset - 1)
             }
             if (element is PsiWhiteSpace) {
-                element = it.findElementAt(element.textRange.startOffset - 1)
+                element = element.prevSibling
             }
             element
         }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/MouseHoverUtil.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/MouseHoverUtil.kt
@@ -20,7 +20,7 @@ object MouseHoverUtil {
      */
     fun targetOffset(event: EditorMouseEvent): Int? {
         return if (this.isHoverInValidArea(event)) {
-            return event.offset
+            event.offset
         } else null
     }
 
@@ -40,7 +40,7 @@ object MouseHoverUtil {
             if (element is PsiWhiteSpace) {
                 element = it.findElementAt(element.textRange.startOffset - 1)
             }
-            return element
+            element
         }
     }
 
@@ -56,7 +56,7 @@ object MouseHoverUtil {
         return event.editor is EditorEx &&
             event.editor.project != null &&
             event.area == EditorMouseEventArea.EDITING_AREA &&
-            event.mouseEvent.modifiers == 0 &&
+            event.mouseEvent.modifiersEx == 0 &&
             event.isOverText &&
             event.collapsedFoldRegion == null
     }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/MouseHoverUtil.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/MouseHoverUtil.kt
@@ -1,0 +1,63 @@
+package com.github.jyoo980.reachhover.util
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseEventArea
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.impl.PsiDocumentManagerImpl
+
+object MouseHoverUtil {
+
+    /**
+     * Calculates the offset within the editor of a mouse [event].
+     *
+     * The offset is returned iff the mouse event is valid, i.e., hovers over unfolded text.
+     *
+     * @return the mouse event offset.
+     */
+    fun targetOffset(event: EditorMouseEvent): Int? {
+        return if (this.isHoverInValidArea(event)) {
+            return event.offset
+        } else null
+    }
+
+    /**
+     * Given a [project], [editor], and [offset], attempt to locate the PsiElement at the location
+     * in the file.
+     *
+     * @return the PsiElement if found.
+     */
+    fun elementAtOffset(project: Project, editor: Editor, offset: Int): PsiElement? {
+        val optFile = PsiDocumentManagerImpl.getInstance(project).getPsiFile(editor.document)
+        return optFile?.let { it ->
+            var element = it.findElementAt(offset)
+            if (element == null && offset == it.textLength) {
+                element = it.findElementAt(offset - 1)
+            }
+            if (element is PsiWhiteSpace) {
+                element = it.findElementAt(element.textRange.startOffset - 1)
+            }
+            return element
+        }
+    }
+
+    /**
+     * Checks whether [event] is a valid mouse event.
+     *
+     * In this case, a valid mouse event is when a mouse hovers over text in an editor, and not
+     * within a collapsed fold region.
+     *
+     * @return the result of a validity check.
+     */
+    private fun isHoverInValidArea(event: EditorMouseEvent): Boolean {
+        return event.editor is EditorEx &&
+            event.editor.project != null &&
+            event.area == EditorMouseEventArea.EDITING_AREA &&
+            event.mouseEvent.modifiers == 0 &&
+            event.isOverText &&
+            event.collapsedFoldRegion == null
+    }
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
@@ -1,4 +1,32 @@
 package com.github.jyoo980.reachhover.util
 
-class PsiExtension {
+import com.intellij.psi.*
+import com.intellij.psi.util.PsiTreeUtil
+
+/**
+ * Extension method on PsiElement.
+ *
+ * @return true iff the element is an instance of a non-literal method argument, e.g., foo(a, 1),
+ * a.isNonLiteralMethodArg() -> true e.g., foo(a, 1), 1.isNonLiteralMethodArg() -> false
+ */
+fun PsiElement.isNonLiteralMethodArg(): Boolean {
+    val optParentMethodCallExpr =
+        PsiTreeUtil.getParentOfType(this, PsiMethodCallExpression::class.java)
+    // Need to check if one of the element's parents is a method list. Otherwise, we get items like
+    // a.foo() being erroneously reported.
+    val optParentExprList = PsiTreeUtil.getParentOfType(this, PsiExpressionList::class.java)
+    return PsiTreeUtil.instanceOf(this, PsiIdentifier::class.java) &&
+        optParentMethodCallExpr != null &&
+        optParentExprList != null
+}
+
+/**
+ * Extension method on PsiElement.
+ *
+ * @return true iff the element is an instance of a local variable reference.
+ */
+fun PsiElement.isLocalVariableReference(): Boolean {
+    val isParentLocalVar =
+        this.parent?.let { PsiTreeUtil.instanceOf(it, PsiLocalVariable::class.java) } ?: false
+    return isParentLocalVar && PsiTreeUtil.instanceOf(this, PsiIdentifier::class.java)
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
@@ -1,0 +1,4 @@
+package com.github.jyoo980.reachhover.util
+
+class PsiExtension {
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
@@ -10,14 +10,9 @@ import com.intellij.psi.util.PsiTreeUtil
  * a.isNonLiteralMethodArg() -> true e.g., foo(a, 1), 1.isNonLiteralMethodArg() -> false
  */
 fun PsiElement.isNonLiteralMethodArg(): Boolean {
-    val optParentMethodCallExpr =
-        PsiTreeUtil.getParentOfType(this, PsiMethodCallExpression::class.java)
-    // Need to check if one of the element's parents is a method list. Otherwise, we get items like
-    // a.foo() being erroneously reported.
-    val optParentExprList = PsiTreeUtil.getParentOfType(this, PsiExpressionList::class.java)
-    return PsiTreeUtil.instanceOf(this, PsiIdentifier::class.java) &&
-        optParentMethodCallExpr != null &&
-        optParentExprList != null
+    PsiTreeUtil.getParentOfType(this, PsiMethodCallExpression::class.java) ?: return false
+    PsiTreeUtil.getParentOfType(this, PsiExpressionList::class.java) ?: return false
+    return PsiTreeUtil.instanceOf(this, PsiIdentifier::class.java)
 }
 
 /**
@@ -26,7 +21,5 @@ fun PsiElement.isNonLiteralMethodArg(): Boolean {
  * @return true iff the element is an instance of a local variable reference.
  */
 fun PsiElement.isLocalVariableReference(): Boolean {
-    val isParentLocalVar =
-        this.parent?.let { PsiTreeUtil.instanceOf(it, PsiLocalVariable::class.java) } ?: false
-    return isParentLocalVar && PsiTreeUtil.instanceOf(this, PsiIdentifier::class.java)
+    return (this is PsiIdentifier) && (this.parent is PsiLocalVariable)
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
     <vendor>jyoo980</vendor>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.github.jyoo980.reachhover.services.MyApplicationService"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,8 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.github.jyoo980.reachhover.services.MyApplicationService"/>
         <projectService serviceImplementation="com.github.jyoo980.reachhover.services.MyProjectService"/>
+        <editorFactoryMouseMotionListener
+                implementation="com.github.jyoo980.reachhover.listeners.EditorHoverListener"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
  * Mainly extracting functionality already implemented in my fork of IntelliJ
    CE.
  * Able to extract the PsiElement under the hover.
  * Added extension methods to `PsiElement` that determine whether an element is a:
     * Non-literal method argument.
     * Non-literal local variable