### PR TITLE
Adding classes for reachability hover popup buttons

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,8 @@ intellij {
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
     plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+    // This enables access to the Java PSI.
+    plugins.set(listOf("com.intellij.java"))
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin

--- a/src/main/kotlin/com/github/jyoo980/reachhover/model/ReachabilityHoverContext.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/model/ReachabilityHoverContext.kt
@@ -1,0 +1,22 @@
+package com.github.jyoo980.reachhover.model
+
+import com.intellij.psi.PsiElement
+import com.intellij.ui.awt.RelativePoint
+
+data class ReachabilityHoverContext(val elementToInspect: PsiElement, val location: RelativePoint) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ReachabilityHoverContext
+
+        if (elementToInspect != other.elementToInspect) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return elementToInspect.hashCode()
+    }
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/services/ReachabilityInfoPopupManager.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/services/ReachabilityInfoPopupManager.kt
@@ -22,9 +22,10 @@ class ReachabilityInfoPopupManager {
             }
         }
         this.optCurrentContext = latestContext
+        // TODO: Really only want to invoke this when the PsiElement is a local variable or a method
+        // argument.
         this.optCurrentContext?.also {
-            val popupUI =
-                this.reachabilityPopupBuilder.constructPopupFor(it.elementToInspect).getUI()
+            val popupUI = this.reachabilityPopupBuilder.constructPopupFor(it.elementToInspect)
             val popup =
                 JBPopupFactory.getInstance()
                     .createComponentPopupBuilder(popupUI, null)

--- a/src/main/kotlin/com/github/jyoo980/reachhover/services/ReachabilityInfoPopupManager.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/services/ReachabilityInfoPopupManager.kt
@@ -1,17 +1,11 @@
 package com.github.jyoo980.reachhover.services
 
 import com.github.jyoo980.reachhover.model.ReachabilityHoverContext
-import com.github.jyoo980.reachhover.ui.BackwardReachabilityButton
 import com.github.jyoo980.reachhover.ui.ReachabilityPopupBuilder
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
-import java.awt.GridLayout
 import java.lang.ref.WeakReference
-import javax.swing.JButton
-import javax.swing.JComponent
-import javax.swing.JPanel
-import javax.swing.SwingConstants
 
 class ReachabilityInfoPopupManager {
 
@@ -39,22 +33,5 @@ class ReachabilityInfoPopupManager {
             this.currentPopupRef = WeakReference(popup)
             popup.show(it.location)
         }
-    }
-
-    private fun component(): JComponent {
-        val panel = JPanel(GridLayout(2, 1))
-        val documentationButton =
-            JButton("Show types and documentation").also {
-                it.horizontalAlignment = SwingConstants.LEFT
-                it.isBorderPainted = false
-                it.isContentAreaFilled = false
-            }
-        this.optCurrentContext?.also {
-            val reachabilityButton = BackwardReachabilityButton(it.elementToInspect)
-            reachabilityButton.setButtonText()
-            panel.add(reachabilityButton.ui)
-        }
-        panel.add(documentationButton)
-        return panel
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/services/ReachabilityInfoPopupManager.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/services/ReachabilityInfoPopupManager.kt
@@ -1,0 +1,60 @@
+package com.github.jyoo980.reachhover.services
+
+import com.github.jyoo980.reachhover.model.ReachabilityHoverContext
+import com.github.jyoo980.reachhover.ui.BackwardReachabilityButton
+import com.github.jyoo980.reachhover.ui.ReachabilityPopupBuilder
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import java.awt.GridLayout
+import java.lang.ref.WeakReference
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+
+class ReachabilityInfoPopupManager {
+
+    private val logger: Logger = Logger.getInstance(ReachabilityInfoPopupManager::class.java)
+    private val reachabilityPopupBuilder: ReachabilityPopupBuilder = ReachabilityPopupBuilder()
+    private var optCurrentContext: ReachabilityHoverContext? = null
+    private var currentPopupRef: WeakReference<JBPopup>? = null
+
+    fun showReachabilityPopupFor(latestContext: ReachabilityHoverContext) {
+        // TODO: probably a much more idiomatic way to do this by using takeIf/takeUnless.
+        if (this.optCurrentContext != null) {
+            if (this.optCurrentContext == latestContext) {
+                return
+            }
+        }
+        this.optCurrentContext = latestContext
+        this.optCurrentContext?.also {
+            val popupUI =
+                this.reachabilityPopupBuilder.constructPopupFor(it.elementToInspect).getUI()
+            val popup =
+                JBPopupFactory.getInstance()
+                    .createComponentPopupBuilder(popupUI, null)
+                    .setCancelOnClickOutside(true)
+                    .createPopup()
+            this.currentPopupRef = WeakReference(popup)
+            popup.show(it.location)
+        }
+    }
+
+    private fun component(): JComponent {
+        val panel = JPanel(GridLayout(2, 1))
+        val documentationButton =
+            JButton("Show types and documentation").also {
+                it.horizontalAlignment = SwingConstants.LEFT
+                it.isBorderPainted = false
+                it.isContentAreaFilled = false
+            }
+        this.optCurrentContext?.also {
+            val reachabilityButton = BackwardReachabilityButton(it.elementToInspect)
+            reachabilityButton.setButtonText()
+            panel.add(reachabilityButton.ui)
+        }
+        panel.add(documentationButton)
+        return panel
+    }
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
@@ -46,7 +46,8 @@ class BackwardReachabilityButton(element: PsiElement) : ReachabilityButton(eleme
             optText
                 ?: kotlin.run {
                     val nameOfArgumentToInspect = this.optIdentifierName() ?: "this argument"
-                    MyBundle.message("createdQuestion", nameOfArgumentToInspect)
+                    val fullText = MyBundle.message("createdQuestion", nameOfArgumentToInspect)
+                    "<html>$fullText</html"
                 }
         this.ui.text = textToSet
     }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
@@ -15,7 +15,7 @@ sealed class ReachabilityButton(element: PsiElement) {
     private val elementUnderCursor = element
     // TODO: Either come up with a custom icon, or find a way to resize (QuestionDialog is 32x32, we
     // need 16x16).
-    val button: JButton =
+    val ui: JButton =
         JButton(AllIcons.General.QuestionDialog).also {
             it.horizontalAlignment = SwingConstants.LEFT
             it.isBorderPainted = false
@@ -27,7 +27,7 @@ sealed class ReachabilityButton(element: PsiElement) {
     open fun activateAction(editor: Editor) {
         // TODO: stub behaviour, link this to actual reachability action later. Should be an
         // abstract fun once we're done.
-        this.button.addActionListener {
+        this.ui.addActionListener {
             Desktop.getDesktop().browse(URI("https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
         }
     }
@@ -39,16 +39,16 @@ sealed class ReachabilityButton(element: PsiElement) {
     }
 }
 
-class ForwardReachabilityButton(element: PsiElement) : ReachabilityButton(element) {
+class BackwardReachabilityButton(element: PsiElement) : ReachabilityButton(element) {
 
     override fun setButtonText() {
         val nameOfArgumentToInspect = this.optIdentifierName() ?: "this argument"
         val textToSet = MyBundle.message("createdQuestion", nameOfArgumentToInspect)
-        this.button.text = "<html>$textToSet</html>"
+        this.ui.text = "<html>$textToSet</html>"
     }
 
     override fun activateAction(editor: Editor) {
-        this.button.addActionListener {
+        this.ui.addActionListener {
             // TODO: wire this up.
         }
     }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
@@ -1,0 +1,55 @@
+package com.github.jyoo980.reachhover.ui
+
+import com.github.jyoo980.reachhover.MyBundle
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiIdentifier
+import java.awt.Desktop
+import java.net.URI
+import javax.swing.JButton
+import javax.swing.SwingConstants
+
+sealed class ReachabilityButton(element: PsiElement) {
+
+    private val elementUnderCursor = element
+    // TODO: Either come up with a custom icon, or find a way to resize (QuestionDialog is 32x32, we
+    // need 16x16).
+    val button: JButton =
+        JButton(AllIcons.General.QuestionDialog).also {
+            it.horizontalAlignment = SwingConstants.LEFT
+            it.isBorderPainted = false
+            it.isContentAreaFilled = false
+        }
+
+    abstract fun setButtonText()
+
+    open fun activateAction(editor: Editor) {
+        // TODO: stub behaviour, link this to actual reachability action later. Should be an
+        // abstract fun once we're done.
+        this.button.addActionListener {
+            Desktop.getDesktop().browse(URI("https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
+        }
+    }
+
+    protected fun optIdentifierName(): String? {
+        return (this.elementUnderCursor as? PsiIdentifier)?.text?.let {
+            "<span style=\"font-family:JetBrains Mono;\">$it</font></span>"
+        }
+    }
+}
+
+class ForwardReachabilityButton(element: PsiElement) : ReachabilityButton(element) {
+
+    override fun setButtonText() {
+        val nameOfArgumentToInspect = this.optIdentifierName() ?: "this argument"
+        val textToSet = MyBundle.message("createdQuestion", nameOfArgumentToInspect)
+        this.button.text = "<html>$textToSet</html>"
+    }
+
+    override fun activateAction(editor: Editor) {
+        this.button.addActionListener {
+            // TODO: wire this up.
+        }
+    }
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
@@ -22,7 +22,7 @@ sealed class ReachabilityButton(element: PsiElement) {
             it.isContentAreaFilled = false
         }
 
-    abstract fun setButtonText()
+    abstract fun setButtonText(optText: String? = null)
 
     open fun activateAction(editor: Editor) {
         // TODO: stub behaviour, link this to actual reachability action later. Should be an
@@ -41,10 +41,14 @@ sealed class ReachabilityButton(element: PsiElement) {
 
 class BackwardReachabilityButton(element: PsiElement) : ReachabilityButton(element) {
 
-    override fun setButtonText() {
-        val nameOfArgumentToInspect = this.optIdentifierName() ?: "this argument"
-        val textToSet = MyBundle.message("createdQuestion", nameOfArgumentToInspect)
-        this.ui.text = "<html>$textToSet</html>"
+    override fun setButtonText(optText: String?) {
+        val textToSet =
+            optText
+                ?: kotlin.run {
+                    val nameOfArgumentToInspect = this.optIdentifierName() ?: "this argument"
+                    MyBundle.message("createdQuestion", nameOfArgumentToInspect)
+                }
+        this.ui.text = textToSet
     }
 
     override fun activateAction(editor: Editor) {

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPopupBuilder.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPopupBuilder.kt
@@ -1,0 +1,31 @@
+package com.github.jyoo980.reachhover.ui
+
+import com.intellij.psi.PsiElement
+import java.awt.GridLayout
+import javax.swing.JPanel
+
+class ReachabilityPopupBuilder {
+
+    // This is the element that the end-user sees when hovering over an element.
+    // Visually, it is a panel with two rows. The first row represents the
+    // Reachability analysis available (where did a value come from/how will a value be modified?).
+    // The second row will be an option to show types/documentation (the unmodified behaviour of
+    // IntelliJ).
+    private val ui: JPanel = JPanel(GridLayout(2, 1))
+
+    fun constructPopupFor(element: PsiElement): ReachabilityPopupBuilder {
+        // TODO: Use extension functions in PsiElement to make the proper calls here depending on
+        // type.
+        // TODO: Eventually register custom actions using ReachabilityButton#activateAction.
+        // TODO: Eventually register custom actions using ShowDocumentationButton#activateAction.
+        val reachabilityButton = BackwardReachabilityButton(element).also { it.setButtonText() }
+        val showDocumentationButton = ShowDocumentationButton().also { it.setButtonText() }
+        this.ui.add(reachabilityButton.ui)
+        this.ui.add(showDocumentationButton.ui)
+        return this
+    }
+
+    fun getUI(): JPanel {
+        return this.ui
+    }
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPopupBuilder.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPopupBuilder.kt
@@ -11,21 +11,18 @@ class ReachabilityPopupBuilder {
     // Reachability analysis available (where did a value come from/how will a value be modified?).
     // The second row will be an option to show types/documentation (the unmodified behaviour of
     // IntelliJ).
-    private val ui: JPanel = JPanel(GridLayout(2, 1))
 
-    fun constructPopupFor(element: PsiElement): ReachabilityPopupBuilder {
+    fun constructPopupFor(element: PsiElement): JPanel {
         // TODO: Use extension functions in PsiElement to make the proper calls here depending on
         // type.
         // TODO: Eventually register custom actions using ReachabilityButton#activateAction.
         // TODO: Eventually register custom actions using ShowDocumentationButton#activateAction.
+        val panel = JPanel(GridLayout(2, 1))
         val reachabilityButton = BackwardReachabilityButton(element).also { it.setButtonText() }
         val showDocumentationButton = ShowDocumentationButton().also { it.setButtonText() }
-        this.ui.add(reachabilityButton.ui)
-        this.ui.add(showDocumentationButton.ui)
-        return this
-    }
-
-    fun getUI(): JPanel {
-        return this.ui
+        return JPanel(GridLayout(2, 1)).also {
+            it.add(reachabilityButton.ui)
+            it.add(showDocumentationButton.ui)
+        }
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
@@ -8,6 +8,9 @@ import javax.swing.SwingConstants
 // TODO: May need to parameterize this with a PsiElement to properly register "Show Docs" action.
 class ShowDocumentationButton {
 
+    // Text of this button reads: "Show types and documentation?"
+    private val defaultButtonText: String = MyBundle.message("showDocumentation")
+
     val ui: JButton =
         JButton(AllIcons.Toolwindows.Documentation).also {
             it.horizontalAlignment = SwingConstants.LEFT
@@ -15,8 +18,8 @@ class ShowDocumentationButton {
             it.isContentAreaFilled = false
         }
 
-    fun setButtonText() {
-        this.ui.text = MyBundle.message("showDocumentation")
+    fun setButtonText(optText: String? = null) {
+        this.ui.text = optText ?: this.defaultButtonText
     }
 
     fun activateAction() {

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
@@ -1,0 +1,27 @@
+package com.github.jyoo980.reachhover.ui
+
+import com.github.jyoo980.reachhover.MyBundle
+import com.intellij.icons.AllIcons
+import javax.swing.JButton
+import javax.swing.SwingConstants
+
+// TODO: May need to parameterize this with a PsiElement to properly register "Show Docs" action.
+class ShowDocumentationButton {
+
+    val ui: JButton =
+        JButton(AllIcons.Toolwindows.Documentation).also {
+            it.horizontalAlignment = SwingConstants.LEFT
+            it.isBorderPainted = false
+            it.isContentAreaFilled = false
+        }
+
+    fun setButtonText() {
+        this.ui.text = MyBundle.message("showDocumentation")
+    }
+
+    fun activateAction() {
+        this.ui.addActionListener {
+            // TODO: wire this up.
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
     <vendor>jyoo980</vendor>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.github.jyoo980.reachhover.services.MyApplicationService"/>

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -1,3 +1,9 @@
 name=My Plugin
 applicationService=Application service
 projectService=Project service: {0}
+
+# Reachability Question Template Strings
+createdQuestion="How was {0} created?"
+
+# Documentation Popup Question
+showDocumentation="Show types and documentation?"

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -3,7 +3,7 @@ applicationService=Application service
 projectService=Project service: {0}
 
 # Reachability Question Template Strings
-createdQuestion="How was {0} created?"
+createdQuestion=How was {0} created?
 
 # Documentation Popup Question
-showDocumentation="Show types and documentation?"
+showDocumentation=Show types and documentation?


### PR DESCRIPTION
  * The `ReachabilityButton` supertype should be extended by all buttons
    related to reachability questions.
  * Currently have a button for answering "Where did x come from" questions.
  * Will need to create a popup manager to create/dispatch calls.