### PR TITLE
Fixing bug with hover for wrong elements in anon classes and lambdas

### DIFF
--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
@@ -6,11 +6,10 @@ import com.intellij.psi.util.PsiTreeUtil
 /**
  * Extension method on PsiElement.
  *
- * INVARIANT:
- * In the event that the cursor is hovering over an anon. class or lambda expr,
- * the location of the first PsiExpressionList object must be closer than that
- * of the first PsiAnonymousClass or PsiLambdaExpression, otherwise we have
- * PsiElements that are not method arguments being reported as such.
+ * INVARIANT: In the event that the cursor is hovering over an anon. class or lambda expr, the
+ * location of the first PsiExpressionList object must be closer than that of the first
+ * PsiAnonymousClass or PsiLambdaExpression, otherwise we have PsiElements that are not method
+ * arguments being reported as such.
  *
  * @return true iff the element is an instance of a non-literal method argument, e.g., foo(a, 1),
  * a.isNonLiteralMethodArg() -> true e.g., foo(a, 1), 1.isNonLiteralMethodArg() -> false

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/PsiExtension.kt
@@ -6,13 +6,25 @@ import com.intellij.psi.util.PsiTreeUtil
 /**
  * Extension method on PsiElement.
  *
+ * INVARIANT:
+ * In the event that the cursor is hovering over an anon. class or lambda expr,
+ * the location of the first PsiExpressionList object must be closer than that
+ * of the first PsiAnonymousClass or PsiLambdaExpression, otherwise we have
+ * PsiElements that are not method arguments being reported as such.
+ *
  * @return true iff the element is an instance of a non-literal method argument, e.g., foo(a, 1),
  * a.isNonLiteralMethodArg() -> true e.g., foo(a, 1), 1.isNonLiteralMethodArg() -> false
  */
 fun PsiElement.isNonLiteralMethodArg(): Boolean {
-    PsiTreeUtil.getParentOfType(this, PsiMethodCallExpression::class.java) ?: return false
-    PsiTreeUtil.getParentOfType(this, PsiExpressionList::class.java) ?: return false
-    return PsiTreeUtil.instanceOf(this, PsiIdentifier::class.java)
+    val parents = PsiTreeUtil.collectParents(this, PsiElement::class.java, false) { it is PsiFile }
+    val locationOfExprList =
+        parents.indexOfFirst { it is PsiExpressionList }.takeIf { it >= 0 } ?: return false
+    val isPsiIdentifier = PsiTreeUtil.instanceOf(this, PsiIdentifier::class.java)
+    return parents
+        .indexOfFirst { it is PsiAnonymousClass || it is PsiLambdaExpression }
+        .takeIf { it >= 0 }
+        ?.let { it -> isPsiIdentifier && locationOfExprList < it }
+        ?: isPsiIdentifier
 }
 
 /**


### PR DESCRIPTION
  * This should close #9
  * Changing `PsiElement#isNonLiteralMethodArg` to account for elements in
    anonymous classes and lambdas.
  * In the hovering occurs over anon. classes/lambdas, the location of the
    first `PsiExpressionList` object must be closer than that of the lambda or
    anon. class Psi object.