### PR TITLE
Adding a title to the reachability popup window

### DIFF
--- a/src/main/kotlin/com/github/jyoo980/reachhover/actions/ShowReachabilityElementsAction.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/actions/ShowReachabilityElementsAction.kt
@@ -12,6 +12,7 @@ import com.intellij.codeInsight.lookup.LookupManager
 import com.intellij.ide.DataManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.ui.popup.ActiveIcon
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.reference.SoftReference
@@ -19,6 +20,7 @@ import com.intellij.slicer.SliceNode
 import com.intellij.ui.popup.AbstractPopup
 import com.intellij.ui.popup.PopupPositionManager
 import com.intellij.ui.popup.PopupUpdateProcessor
+import icons.IconManager
 import java.lang.ref.Reference
 import java.lang.ref.WeakReference
 
@@ -32,11 +34,11 @@ class ShowReachabilityElementsAction {
         root: SliceNode,
         dataflowFromHere: Boolean
     ) {
-        val (editor, exprUnderInspection, tree) = context
+        val (editor, exprUnderInspection, questionText, tree) = context
         val reachabilityViewElements =
             tree.map { metadata -> metadata.element?.let { ReachabilityViewElement(it) }!! }
         ReachabilityElementViewSession(editor, exprUnderInspection, reachabilityViewElements).also {
-            showReachabilitySession(it, editor, root, dataflowFromHere)
+            showReachabilitySession(it, editor, root, questionText, dataflowFromHere)
         }
     }
 
@@ -44,11 +46,11 @@ class ShowReachabilityElementsAction {
         session: ImplementationViewSession,
         editor: Editor,
         root: SliceNode,
+        questionText: String,
         dataflowFromHere: Boolean
     ) {
         if (session.implementationElements.isNotEmpty()) {
             // TODO: come up with an actual title based on the element/expression under analysis
-            val title = "Reachability View..."
             session.implementationElements.forEach {
                 logger.info("ViewElement Impl: ${it.elementForShowUsages}")
             }
@@ -83,6 +85,8 @@ class ShowReachabilityElementsAction {
                     .setProject(editor.project)
                     .addListener(updateProcessor)
                     .addUserData(updateProcessor)
+                    .setTitle(questionText)
+                    .setTitleIcon(IconManager.reachabilityIcon.let(::ActiveIcon))
                     .setDimensionServiceKey(
                         editor.project,
                         DocumentationManager.JAVADOC_LOCATION_AND_SIZE,

--- a/src/main/kotlin/com/github/jyoo980/reachhover/model/ReachabilityContext.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/model/ReachabilityContext.kt
@@ -6,5 +6,6 @@ import com.intellij.psi.PsiElement
 data class ReachabilityContext(
     val editor: Editor,
     val element: PsiElement,
+    val questionText: String,
     val tree: Tree<SliceMetadata>
 )

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
@@ -41,6 +41,7 @@ sealed class ReachabilityButton(
                         ReachabilityContext(
                             editor,
                             expr,
+                            questionText(),
                             SliceMetadataTransformer().transform(tree)
                         )
                     ShowReachabilityElementsAction()
@@ -54,6 +55,12 @@ sealed class ReachabilityButton(
         return (element as? PsiIdentifier)?.text?.let {
             "<span style=\"font-family:JetBrains Mono;\">$it</font></span>"
         }
+    }
+
+    private fun questionText(): String {
+        val inspectedName = identifierName() ?: "this argument"
+        val key = if (dataflowFromHere) "modifiedQuestion" else "createdQuestion"
+        return "<html>${MyBundle.message(key, inspectedName)}</html>"
     }
 }
 


### PR DESCRIPTION
  * The reachability window now has a centered title bar at the top.
  * A user is now able to move the window by selecting the title bar and
    dragging it around.

Should eventually resolve #22 and #25.