### PR TITLE
Enable a wider variety of reachability analysis scopes

### DIFF
--- a/src/main/kotlin/com/github/jyoo980/reachhover/actions/ShowReachabilityElementsAction.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/actions/ShowReachabilityElementsAction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ui.popup.ActiveIcon
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.psi.PsiElement
 import com.intellij.reference.SoftReference
 import com.intellij.slicer.SliceNode
 import com.intellij.ui.popup.PopupPositionManager
@@ -26,12 +27,13 @@ class ShowReachabilityElementsAction {
         root: SliceNode,
         dataflowFromHere: Boolean
     ) {
-        val (editor, _, questionText) = context
-        showReachabilitySession(editor, root, questionText, dataflowFromHere)
+        val (editor, elementUnderAnalysis, questionText) = context
+        showReachabilitySession(editor, elementUnderAnalysis, root, questionText, dataflowFromHere)
     }
 
     private fun showReachabilitySession(
         editor: Editor,
+        elementUnderAnalysis: PsiElement,
         root: SliceNode,
         questionText: String,
         dataflowFromHere: Boolean
@@ -43,6 +45,7 @@ class ShowReachabilityElementsAction {
         val viewComponent =
             object :
                 ReachabilityPanel(
+                    elementUnderAnalysis,
                     project,
                     dataflowFromHere,
                     root,

--- a/src/main/kotlin/com/github/jyoo980/reachhover/services/slicer/SliceDispatchService.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/services/slicer/SliceDispatchService.kt
@@ -28,6 +28,18 @@ object SliceDispatchService {
         )
     }
 
+    fun sliceRootUsage(
+        elementAtHover: PsiElement,
+        project: Project,
+        params: SliceAnalysisParams
+    ): SliceRootNode {
+        return SliceRootNode(
+            project,
+            DuplicateMap(),
+            LanguageSlicing.getProvider(elementAtHover).createRootUsage(elementAtHover, params)
+        )
+    }
+
     private fun defaultAnalysisParams(
         element: PsiElement,
         isForwardSlice: Boolean

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPanel.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPanel.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.ui.OnePixelDivider
 import com.intellij.openapi.ui.Splitter
 import com.intellij.openapi.util.Disposer
 import com.intellij.pom.Navigatable
+import com.intellij.psi.PsiElement
 import com.intellij.slicer.SliceLanguageSupportProvider
 import com.intellij.slicer.SliceNode
 import com.intellij.slicer.SliceUsageCellRendererBase
@@ -42,13 +43,14 @@ import javax.swing.event.TreeWillExpandListener
 import javax.swing.tree.*
 
 abstract class ReachabilityPanel(
+    val elementUnderAnalysis: PsiElement,
     project: Project,
-    dataFlowToThis: Boolean,
+    val dataFlowToThis: Boolean,
     rootNode: SliceNode,
-    splitByLeafExpressions: Boolean,
+    val splitByLeafExpressions: Boolean,
 ) : JPanel(BorderLayout()), DataProvider, Disposable {
-    private val myBuilder: SliceTreeBuilder
-    private val myTree: JTree
+    private lateinit var myBuilder: SliceTreeBuilder
+    private lateinit var myTree: JTree
     private val myAutoScrollToSourceHandler: AutoScrollToSourceHandler =
         object : AutoScrollToSourceHandler() {
             override fun isAutoScrollMode(): Boolean {
@@ -69,6 +71,17 @@ abstract class ReachabilityPanel(
         myProvider = rootNode.provider
         ApplicationManager.getApplication().assertIsDispatchThread()
         myProject = project
+        initTree(project, dataFlowToThis, rootNode, splitByLeafExpressions)
+        val scopesPanel = ReachabilityScopePanel(this)
+        layoutPanel(scopesPanel)
+    }
+
+    fun initTree(
+        project: Project,
+        dataFlowToThis: Boolean,
+        rootNode: SliceNode,
+        splitByLeafExpressions: Boolean
+    ) {
         myTree = createTree()
         myBuilder =
             SliceTreeBuilder(myTree, project, dataFlowToThis, rootNode, splitByLeafExpressions)
@@ -87,10 +100,36 @@ abstract class ReachabilityPanel(
             }
             treeSelectionChanged()
         }
-        layoutPanel()
     }
 
-    private fun layoutPanel() {
+    fun refreshTree(rootNode: SliceNode, scopePanel: ReachabilityScopePanel) {
+        myTree = createTree()
+        myBuilder =
+            SliceTreeBuilder(
+                myTree,
+                elementUnderAnalysis.project,
+                dataFlowToThis,
+                rootNode,
+                splitByLeafExpressions
+            )
+        myBuilder.setCanYieldUpdate(!ApplicationManager.getApplication().isUnitTestMode)
+        myBuilder.addSubtreeToUpdate(myTree.model.root as DefaultMutableTreeNode) {
+            if (isDisposed || myBuilder.isDisposed || myProject.isDisposed)
+                return@addSubtreeToUpdate
+            val rootNode1 = myBuilder.getRootSliceNode()
+            myBuilder.expand(rootNode1) {
+                if (isDisposed || myBuilder.isDisposed || myProject.isDisposed) return@expand
+                val children = rootNode1.cachedChildren
+                if (children.isNotEmpty()) {
+                    myBuilder.select(children[0]) // first there is ony one child
+                }
+            }
+            treeSelectionChanged()
+        }
+        layoutPanel(scopePanel)
+    }
+
+    private fun layoutPanel(scopesPanel: ReachabilityScopePanel) {
         myUsagePreviewPanel?.let { Disposer.dispose(it) }
         removeAll()
         val pane = ScrollPaneFactory.createScrollPane(myTree)
@@ -102,7 +141,6 @@ abstract class ReachabilityPanel(
         myUsagePreviewPanel?.let { Disposer.register(this, it) }
         splitter.secondComponent = myUsagePreviewPanel
         splitter.divider.background = OnePixelDivider.BACKGROUND
-        val scopesPanel = ReachabilityScopePanel()
         add(scopesPanel, BorderLayout.NORTH)
         add(splitter, BorderLayout.CENTER)
         myLabel?.let { add(it, BorderLayout.SOUTH) }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPanel.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPanel.kt
@@ -1,6 +1,7 @@
 package com.github.jyoo980.reachhover.ui
 
 import com.github.jyoo980.reachhover.model.SliceTreeBuilder
+import com.github.jyoo980.reachhover.ui.scope.ReachabilityScopePanel
 import com.github.jyoo980.reachhover.util.PresentationUtil
 import com.intellij.ide.DefaultTreeExpander
 import com.intellij.ide.util.treeView.AbstractTreeNode
@@ -32,7 +33,10 @@ import java.awt.Component
 import java.awt.GridLayout
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
-import javax.swing.*
+import javax.swing.JPanel
+import javax.swing.JTree
+import javax.swing.SwingUtilities
+import javax.swing.ToolTipManager
 import javax.swing.event.TreeExpansionEvent
 import javax.swing.event.TreeWillExpandListener
 import javax.swing.tree.*
@@ -98,6 +102,8 @@ abstract class ReachabilityPanel(
         myUsagePreviewPanel?.let { Disposer.register(this, it) }
         splitter.secondComponent = myUsagePreviewPanel
         splitter.divider.background = OnePixelDivider.BACKGROUND
+        val scopesPanel = ReachabilityScopePanel()
+        add(scopesPanel, BorderLayout.NORTH)
         add(splitter, BorderLayout.CENTER)
         myLabel?.let { add(it, BorderLayout.SOUTH) }
         myTree.parent.background = UIUtil.getTreeBackground()

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/ReachabilityScopePanel.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/ReachabilityScopePanel.kt
@@ -1,11 +1,17 @@
 package com.github.jyoo980.reachhover.ui.scope
 
+import com.github.jyoo980.reachhover.services.slicer.SliceDispatchService
+import com.github.jyoo980.reachhover.ui.ReachabilityPanel
+import com.intellij.psi.PsiElement
+import com.intellij.slicer.SliceAnalysisParams
+import com.intellij.slicer.SliceRootNode
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.JButton
 import javax.swing.JToolBar
 
-class ReachabilityScopePanel : JToolBar(), ScopePanelStyler {
+class ReachabilityScopePanel(val reachabilityPanel: ReachabilityPanel) :
+    JToolBar(), ScopePanelStyler {
 
     private val supportedScopes: List<Scope> = listOf(Project, Module, File)
     private val scopeSelectionButtons = supportedScopes.map(::scopeButton)
@@ -17,25 +23,47 @@ class ReachabilityScopePanel : JToolBar(), ScopePanelStyler {
     }
 
     private fun scopeButton(scope: Scope): JButton {
-        return JButton(scope.name).also {
+        return ScopeButton(scope).also {
             applyDefaultStyle(it)
-            it.addMouseListener(
-                object : MouseAdapter() {
-                    override fun mouseEntered(e: MouseEvent?) {
-                        it.isContentAreaFilled = true
-                    }
-                    override fun mouseExited(e: MouseEvent?) {
-                        it.isContentAreaFilled = false
-                    }
-
-                    override fun mouseClicked(e: MouseEvent?) {
-                        it.isBorderPainted = !it.isBorderPainted
-                        scopeSelectionButtons.filterNot { other -> other == it }.forEach { other ->
-                            applyDefaultStyle(other)
-                        }
-                    }
-                }
-            )
+            attachActions(it)
         }
     }
+
+    private fun attachActions(button: ScopeButton) {
+        button.addMouseListener(
+            object : MouseAdapter() {
+                override fun mouseEntered(e: MouseEvent?) {
+                    button.isContentAreaFilled = true
+                }
+                override fun mouseExited(e: MouseEvent?) {
+                    button.isContentAreaFilled = false
+                }
+
+                override fun mouseClicked(e: MouseEvent?) {
+                    button.isBorderPainted = !button.isBorderPainted
+                    scopeSelectionButtons.filterNot { other -> other == button }.forEach { other ->
+                        applyDefaultStyle(other)
+                    }
+                    val updatedSliceRoot = foo(reachabilityPanel.elementUnderAnalysis, button.scope)
+                    reachabilityPanel.refreshTree(updatedSliceRoot, this@ReachabilityScopePanel)
+                }
+            }
+        )
+    }
+
+    private fun foo(elementToAnalyze: PsiElement, selectedScope: Scope): SliceRootNode {
+        val analysisParams =
+            SliceAnalysisParams().apply {
+                dataFlowToThis = !reachabilityPanel.dataFlowToThis
+                showInstanceDereferences = true
+                scope = selectedScope.analysisScope(elementToAnalyze)
+            }
+        return SliceDispatchService.sliceRootUsage(
+            elementToAnalyze,
+            elementToAnalyze.project,
+            analysisParams
+        )
+    }
 }
+
+class ScopeButton(val scope: Scope) : JButton(scope.name, scope.icon)

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/ReachabilityScopePanel.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/ReachabilityScopePanel.kt
@@ -1,0 +1,41 @@
+package com.github.jyoo980.reachhover.ui.scope
+
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.JButton
+import javax.swing.JToolBar
+
+class ReachabilityScopePanel : JToolBar(), ScopePanelStyler {
+
+    private val supportedScopes: List<Scope> = listOf(Project, Module, File)
+    private val scopeSelectionButtons = supportedScopes.map(::scopeButton)
+
+    init {
+        scopeSelectionButtons.forEachIndexed { i, button -> add(button, i) }
+        this.border = panelBorder()
+        this.isFloatable = false
+    }
+
+    private fun scopeButton(scope: Scope): JButton {
+        return JButton(scope.name).also {
+            applyDefaultStyle(it)
+            it.addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseEntered(e: MouseEvent?) {
+                        it.isContentAreaFilled = true
+                    }
+                    override fun mouseExited(e: MouseEvent?) {
+                        it.isContentAreaFilled = false
+                    }
+
+                    override fun mouseClicked(e: MouseEvent?) {
+                        it.isBorderPainted = !it.isBorderPainted
+                        scopeSelectionButtons.filterNot { other -> other == it }.forEach { other ->
+                            applyDefaultStyle(other)
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/Scope.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/Scope.kt
@@ -1,0 +1,12 @@
+package com.github.jyoo980.reachhover.ui.scope
+
+import com.intellij.util.ui.EmptyIcon
+import javax.swing.Icon
+
+sealed class Scope(val name: String, val icon: Icon = EmptyIcon.ICON_0)
+
+object Project : Scope(name = "In Project")
+
+object Module : Scope(name = "Module")
+
+object File : Scope(name = "File")

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/Scope.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/Scope.kt
@@ -1,12 +1,24 @@
 package com.github.jyoo980.reachhover.ui.scope
 
+import com.intellij.analysis.AnalysisScope
+import com.intellij.psi.PsiElement
 import com.intellij.util.ui.EmptyIcon
 import javax.swing.Icon
 
-sealed class Scope(val name: String, val icon: Icon = EmptyIcon.ICON_0)
+abstract class Scope(val name: String, val icon: Icon = EmptyIcon.ICON_0) {
+    abstract fun analysisScope(element: PsiElement): AnalysisScope
+}
 
-object Project : Scope(name = "In Project")
+object Project : Scope(name = "In Project") {
+    override fun analysisScope(element: PsiElement): AnalysisScope = AnalysisScope(element.project)
+}
 
-object Module : Scope(name = "Module")
+object Module : Scope(name = "Module") {
+    // TODO: how do I analyze the module?
+    override fun analysisScope(element: PsiElement): AnalysisScope = AnalysisScope(element.project)
+}
 
-object File : Scope(name = "File")
+object File : Scope(name = "File") {
+    override fun analysisScope(element: PsiElement): AnalysisScope =
+        AnalysisScope(element.containingFile)
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/ScopePanelStyler.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/scope/ScopePanelStyler.kt
@@ -1,0 +1,19 @@
+package com.github.jyoo980.reachhover.ui.scope
+
+import com.intellij.ui.JBColor
+import com.intellij.util.ui.JBUI
+import java.awt.Dimension
+import javax.swing.JButton
+import javax.swing.border.Border
+
+interface ScopePanelStyler {
+
+    fun panelBorder(): Border = JBUI.Borders.customLine(JBColor.border(), 1, 0, 0, 0)
+
+    fun applyDefaultStyle(button: JButton) {
+        button.isOpaque = false
+        button.isContentAreaFilled = false
+        button.isBorderPainted = false
+        button.maximumSize = Dimension(75, 25)
+    }
+}


### PR DESCRIPTION
  * Scope selection now available for `Project` and `File`.
    * TODO: still need to figure out how to do this for the module-level
      analyses.
  * Think about whether the re-drawing of the tree is annoying; can we do this
    without the "flash" happening for the UI redraw?

Closes #20 