### PR TITLE
Fixing reachability popup location

### DIFF
--- a/src/main/kotlin/com/github/jyoo980/reachhover/actions/ShowReachabilityElementsAction.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/actions/ShowReachabilityElementsAction.kt
@@ -4,7 +4,7 @@ import com.github.jyoo980.reachhover.model.ReachabilityContext
 import com.github.jyoo980.reachhover.ui.ReachabilityPanel
 import com.intellij.codeInsight.documentation.DocumentationManager
 import com.intellij.codeInsight.lookup.LookupManager
-import com.intellij.ide.DataManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ui.popup.ActiveIcon
 import com.intellij.openapi.ui.popup.JBPopup
@@ -12,7 +12,7 @@ import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.psi.PsiElement
 import com.intellij.reference.SoftReference
 import com.intellij.slicer.SliceNode
-import com.intellij.ui.popup.PopupPositionManager
+import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.popup.PopupUpdateProcessor
 import com.intellij.util.ui.JBDimension
 import icons.IconManager
@@ -21,16 +21,25 @@ import java.lang.ref.WeakReference
 
 class ShowReachabilityElementsAction {
 
+    private val logger: Logger = Logger.getInstance(ShowReachabilityElementsAction::class.java)
     private var popupRef: Reference<JBPopup>? = null
     private val minimumPopupSize: JBDimension = JBDimension(566, 717, false)
 
     fun performForContext(
         context: ReachabilityContext,
         root: SliceNode,
-        dataflowFromHere: Boolean
+        dataflowFromHere: Boolean,
+        location: RelativePoint
     ) {
         val (editor, elementUnderAnalysis, questionText) = context
-        showReachabilitySession(editor, elementUnderAnalysis, root, questionText, dataflowFromHere)
+        showReachabilitySession(
+            editor,
+            elementUnderAnalysis,
+            root,
+            questionText,
+            dataflowFromHere,
+            location
+        )
     }
 
     private fun showReachabilitySession(
@@ -38,7 +47,8 @@ class ShowReachabilityElementsAction {
         elementUnderAnalysis: PsiElement,
         root: SliceNode,
         questionText: String,
-        dataflowFromHere: Boolean
+        dataflowFromHere: Boolean,
+        location: RelativePoint
     ) {
         var popup = SoftReference.dereference(popupRef)
         val project = editor.project ?: return
@@ -77,11 +87,7 @@ class ShowReachabilityElementsAction {
                 .setMinSize(minimumPopupSize)
                 .setRequestFocus(LookupManager.getActiveLookup(editor) != null)
         popup = popupBuilder.createPopup()
-        PopupPositionManager.positionPopupInBestPosition(
-            popup,
-            editor,
-            DataManager.getInstance().getDataContext()
-        )
+        popup.show(location)
         popupRef = WeakReference(popup)
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityButton.kt
@@ -7,6 +7,7 @@ import com.github.jyoo980.reachhover.services.slicer.SliceDispatchService
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiIdentifier
+import com.intellij.ui.awt.RelativePoint
 import icons.IconManager
 import javax.swing.JButton
 import javax.swing.SwingConstants
@@ -25,7 +26,7 @@ sealed class ReachabilityButton(
 
     abstract fun setButtonText(text: String? = null)
 
-    fun activateAction(editor: Editor) {
+    fun activateAction(editor: Editor, location: RelativePoint) {
         editor.project?.also { project ->
             ui.addActionListener {
                 val expressionToAnalyze =
@@ -40,7 +41,12 @@ sealed class ReachabilityButton(
                             questionText(),
                         )
                     ShowReachabilityElementsAction()
-                        .performForContext(reachabilityContext, sliceRoot, dataflowFromHere)
+                        .performForContext(
+                            reachabilityContext,
+                            sliceRoot,
+                            dataflowFromHere,
+                            location
+                        )
                 }
             }
         }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPopupBuilder.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPopupBuilder.kt
@@ -16,11 +16,11 @@ class ReachabilityPopupBuilder {
     // IntelliJ).
 
     fun constructPopupFor(reachabilityContext: ReachabilityHoverContext): JPanel {
-        val (element, _, editor) = reachabilityContext
+        val (element, location, editor) = reachabilityContext
         val reachabilityButton =
             createReachabilityButton(element)?.apply {
                 setButtonText()
-                activateAction(editor)
+                activateAction(editor, location)
             }
         val showDocumentationButton =
             ShowDocumentationButton().apply {


### PR DESCRIPTION
  * Previously the reachability popup appeared at the last selected *caret*
    location. This is an issue, since it's not guaranteed that users who hover
    over an element will also click on it with the caret.
  * This is mitgated by using the `RelativePoint` obtained from the editor pane
    for the hover location.

Closes #26.