### PR TITLE
[ENHANCEMENT] Implementing documentation button

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.0.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 211
+pluginSinceBuild = 213
 pluginUntilBuild = 221.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties

--- a/src/main/kotlin/com/github/jyoo980/reachhover/listeners/EditorHoverListener.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/listeners/EditorHoverListener.kt
@@ -43,7 +43,8 @@ internal class EditorHoverListener : EditorMouseMotionListener {
                             RelativePoint(e.mouseEvent),
                             e.editor,
                             isForwardAnalysis,
-                            unifiedAstElement?.presentableName() ?: ""
+                            unifiedAstElement?.presentableName() ?: "",
+                            offset
                         )
                     reachabilityPopupManager.showReachabilityPopupFor(context)
                 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/model/ReachabilityHoverContext.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/model/ReachabilityHoverContext.kt
@@ -10,4 +10,5 @@ data class ReachabilityHoverContext(
     val editor: Editor,
     val isForwardAnalysis: Boolean,
     val elementName: String,
+    val offsetInEditor: Int
 )

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPopupBuilder.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPopupBuilder.kt
@@ -14,16 +14,17 @@ class ReachabilityPopupBuilder {
     // IntelliJ).
 
     fun constructPopupFor(reachabilityContext: ReachabilityHoverContext): JPanel {
-        val (element, location, editor, isForwardAnalysis, identifierName) = reachabilityContext
+        val (element, location, editor, isForwardAnalysis, identifierName, offset) =
+            reachabilityContext
         val reachabilityButton =
             createReachabilityButton(element, isForwardAnalysis).apply {
                 setButtonText(identifierName)
                 activateAction(editor, location)
             }
         val showDocumentationButton =
-            ShowDocumentationButton().apply {
+            ShowDocumentationButton(element).apply {
                 setButtonText()
-                activateAction()
+                activateAction(offset, editor, location)
             }
         return JPanel(GridLayout(2, 1)).apply {
             reachabilityButton.let { this.add(it.ui) }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
@@ -4,7 +4,6 @@ import com.github.jyoo980.reachhover.MyBundle
 import com.intellij.codeInsight.documentation.DocumentationManager
 import com.intellij.codeInsight.lookup.LookupManager
 import com.intellij.lang.documentation.ide.impl.IdeDocumentationTargetProviderImpl
-import com.intellij.lang.documentation.psi.PsiElementDocumentationTarget
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.psi.PsiElement
@@ -41,9 +40,9 @@ class ShowDocumentationButton(private val element: PsiElement) {
                     element.containingFile,
                     offset
                 )
-            targets.takeIf { it.isNotEmpty() }?.let {
-                val targets = it.first() as? PsiElementDocumentationTarget
-                val hint = targets?.computeDocumentationHint()
+            documentationTargets(editor, offset)?.let { (targetElement, sourceElement) ->
+                val doc = DocumentationManager.getProviderFromElement(element)
+                val hint = doc.generateDoc(targetElement, sourceElement)
                 val component = hint?.let(::JBLabel)
                 component?.let { docComponent ->
                     docComponent.border = JBUI.Borders.empty(10)
@@ -51,11 +50,6 @@ class ShowDocumentationButton(private val element: PsiElement) {
                         JBPopupFactory.getInstance()
                             .createComponentPopupBuilder(docComponent, docComponent)
                             .setProject(editor.project)
-                            .setDimensionServiceKey(
-                                editor.project,
-                                DocumentationManager.JAVADOC_LOCATION_AND_SIZE,
-                                false
-                            )
                             .setResizable(true)
                             .setMovable(true)
                             .setRequestFocus(LookupManager.getActiveLookup(editor) != null)
@@ -64,5 +58,12 @@ class ShowDocumentationButton(private val element: PsiElement) {
                 }
             }
         }
+    }
+
+    private fun documentationTargets(editor: Editor, offset: Int): Pair<PsiElement, PsiElement?>? {
+        val docManager = DocumentationManager(element.project)
+        val elements =
+            docManager.findTargetElementAndContext(editor, offset, element.containingFile)
+        return elements?.let { it -> it.first to it.second }
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
@@ -4,6 +4,7 @@ import com.github.jyoo980.reachhover.MyBundle
 import com.intellij.codeInsight.documentation.DocumentationManager
 import com.intellij.codeInsight.lookup.LookupManager
 import com.intellij.lang.documentation.ide.impl.IdeDocumentationTargetProviderImpl
+import com.intellij.lang.documentation.psi.PsiElementDocumentationTarget
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.psi.PsiElement
@@ -41,8 +42,8 @@ class ShowDocumentationButton(private val element: PsiElement) {
                     offset
                 )
             targets.takeIf { it.isNotEmpty() }?.let {
-                val targets = it.first()
-                val hint = targets.computeDocumentationHint()
+                val targets = it.first() as? PsiElementDocumentationTarget
+                val hint = targets?.computeDocumentationHint()
                 val component = hint?.let(::JBLabel)
                 component?.let { docComponent ->
                     docComponent.border = JBUI.Borders.empty(10)

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
@@ -3,7 +3,6 @@ package com.github.jyoo980.reachhover.ui
 import com.github.jyoo980.reachhover.MyBundle
 import com.intellij.codeInsight.documentation.DocumentationManager
 import com.intellij.codeInsight.lookup.LookupManager
-import com.intellij.lang.documentation.ide.impl.IdeDocumentationTargetProviderImpl
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.psi.PsiElement
@@ -33,16 +32,9 @@ class ShowDocumentationButton(private val element: PsiElement) {
 
     fun activateAction(offset: Int, editor: Editor, location: RelativePoint) {
         ui.addActionListener {
-            val documentationTargetProvider = IdeDocumentationTargetProviderImpl(element.project)
-            val targets =
-                documentationTargetProvider.documentationTargets(
-                    editor,
-                    element.containingFile,
-                    offset
-                )
             documentationTargets(editor, offset)?.let { (targetElement, sourceElement) ->
-                val doc = DocumentationManager.getProviderFromElement(element)
-                val hint = doc.generateDoc(targetElement, sourceElement)
+                val docProvider = DocumentationManager.getProviderFromElement(element)
+                val hint = docProvider.generateDoc(targetElement, sourceElement)
                 val component = hint?.let(::JBLabel)
                 component?.let { docComponent ->
                     docComponent.border = JBUI.Borders.empty(10)

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
@@ -1,15 +1,26 @@
 package com.github.jyoo980.reachhover.ui
 
 import com.github.jyoo980.reachhover.MyBundle
+import com.intellij.codeInsight.documentation.DocumentationManager
+import com.intellij.codeInsight.lookup.LookupManager
+import com.intellij.lang.documentation.ide.impl.IdeDocumentationTargetProviderImpl
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.psi.PsiElement
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
 import icons.IconManager
 import javax.swing.JButton
 import javax.swing.SwingConstants
 
 // TODO: May need to parameterize this with a PsiElement to properly register "Show Docs" action.
-class ShowDocumentationButton {
+class ShowDocumentationButton(private val element: PsiElement) {
 
     // Text of this button reads: "Show types and documentation?"
     private val defaultButtonText: String = MyBundle.message("showDocumentation")
+    private val logger = Logger.getInstance(ShowDocumentationButton::class.java)
 
     val ui: JButton =
         JButton(IconManager.documentationIcon).apply {
@@ -22,9 +33,37 @@ class ShowDocumentationButton {
         ui.text = optText ?: defaultButtonText
     }
 
-    fun activateAction() {
+    fun activateAction(offset: Int, editor: Editor, location: RelativePoint) {
         ui.addActionListener {
-            // TODO: wire this up.
+            val documentationTargetProvider = IdeDocumentationTargetProviderImpl(element.project)
+            val targets =
+                documentationTargetProvider.documentationTargets(
+                    editor,
+                    element.containingFile,
+                    offset
+                )
+            targets.takeIf { it.isNotEmpty() }?.let {
+                val targets = it.first()
+                val hint = targets.computeDocumentationHint()
+                val component = hint?.let(::JBLabel)
+                component?.let { docComponent ->
+                    docComponent.border = JBUI.Borders.empty(10)
+                    val popupBuilder =
+                        JBPopupFactory.getInstance()
+                            .createComponentPopupBuilder(docComponent, docComponent)
+                            .setProject(editor.project)
+                            .setDimensionServiceKey(
+                                editor.project,
+                                DocumentationManager.JAVADOC_LOCATION_AND_SIZE,
+                                false
+                            )
+                            .setResizable(true)
+                            .setMovable(true)
+                            .setRequestFocus(LookupManager.getActiveLookup(editor) != null)
+                    val popup = popupBuilder.createPopup()
+                    popup.show(location)
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
@@ -4,7 +4,6 @@ import com.github.jyoo980.reachhover.MyBundle
 import com.intellij.codeInsight.documentation.DocumentationManager
 import com.intellij.codeInsight.lookup.LookupManager
 import com.intellij.lang.documentation.ide.impl.IdeDocumentationTargetProviderImpl
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.psi.PsiElement
@@ -15,12 +14,11 @@ import icons.IconManager
 import javax.swing.JButton
 import javax.swing.SwingConstants
 
-// TODO: May need to parameterize this with a PsiElement to properly register "Show Docs" action.
+@Suppress("UnstableApiUsage")
 class ShowDocumentationButton(private val element: PsiElement) {
 
     // Text of this button reads: "Show types and documentation?"
     private val defaultButtonText: String = MyBundle.message("showDocumentation")
-    private val logger = Logger.getInstance(ShowDocumentationButton::class.java)
 
     val ui: JButton =
         JButton(IconManager.documentationIcon).apply {


### PR DESCRIPTION
The `reach-hover` popup has two buttons. The top button invokes the newly
implemented reachability UI. The bottom button should enable developers to
fall back to the classic types/documentation view that was present before
the change.