### PR TITLE
Adding feature to log reach-hover logs to file

### DIFF
--- a/src/main/kotlin/com/github/jyoo980/reachhover/actions/FinishTaskAction.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/actions/FinishTaskAction.kt
@@ -1,17 +1,16 @@
 package com.github.jyoo980.reachhover.actions
 
+import com.github.jyoo980.reachhover.analytics.EventType
+import com.github.jyoo980.reachhover.analytics.LogWriter
 import com.github.jyoo980.reachhover.services.NotificationService
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.diagnostic.Logger
 import icons.IconManager
 
 class FinishTaskAction : AnAction(IconManager.completeTaskIcon) {
 
-    private val logger: Logger = Logger.getInstance(FinishTaskAction::class.java)
-
     override fun actionPerformed(e: AnActionEvent) {
-        logger.info("==== ReachHover: Task Finished ====")
+        LogWriter.write("Task Finished", EventType.TASK_FINISH)
         e.project?.let { NotificationService.showNotification(it, "Task Finished") }
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/actions/StartTaskAction.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/actions/StartTaskAction.kt
@@ -1,17 +1,16 @@
 package com.github.jyoo980.reachhover.actions
 
+import com.github.jyoo980.reachhover.analytics.EventType
+import com.github.jyoo980.reachhover.analytics.LogWriter
 import com.github.jyoo980.reachhover.services.NotificationService
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.diagnostic.Logger
 import icons.IconManager
 
 class StartTaskAction : AnAction(IconManager.startTaskIcon) {
 
-    private val logger: Logger = Logger.getInstance(StartTaskAction::class.java)
-
     override fun actionPerformed(e: AnActionEvent) {
-        logger.info("==== ReachHover: Task Started ====")
+        LogWriter.write("Task Started", EventType.TASK_START)
         e.project?.let { NotificationService.showNotification(it, "Task Started") }
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/analytics/FileListener.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/analytics/FileListener.kt
@@ -1,23 +1,20 @@
 package com.github.jyoo980.reachhover.analytics
 
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.vfs.VirtualFile
 
 class FileListener : FileEditorManagerListener {
 
-    private val logger: Logger = Logger.getInstance(FileListener::class.java)
-
     // Should be okay to collect which files are open, given we provide the project in the
     // experiment, but I'm going to obfuscate the name of the file by just hashing its string rep.
     override fun fileOpened(source: FileEditorManager, file: VirtualFile) {
         val hashedFileName = file.name.hashCode()
-        logger.info("==== File Listener: Opened '$hashedFileName' ====")
+        LogWriter.write("Opened $hashedFileName", EventType.FILE_OPEN)
     }
 
     override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
         val hashedFileName = file.name.hashCode()
-        logger.info("==== File Listener: Closed '$hashedFileName' ====")
+        LogWriter.write("Closed '$hashedFileName'", EventType.FILE_CLOSED)
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/analytics/LogWriter.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/analytics/LogWriter.kt
@@ -1,0 +1,52 @@
+package com.github.jyoo980.reachhover.analytics
+
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.diagnostic.Logger
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileWriter
+import java.time.Instant
+
+object LogWriter : TimeUtil {
+
+    private val logger: Logger = Logger.getInstance(LogWriter::class.java)
+    private val logFilePath = "${PathManager.getLogPath()}/reach-hover/reach-hover.log"
+
+    init {
+        val file = File(logFilePath)
+        if (file.exists()) {
+            file.delete()
+        }
+        if (file.parentFile.mkdir()) {
+            try {
+                file.createNewFile()
+            } catch (e: Exception) {
+                logger.error("Failed to create logging file for reach-hover", e)
+            }
+        }
+    }
+
+    fun write(message: String, type: EventType) {
+        try {
+            val writer = BufferedWriter(FileWriter(logFilePath, true))
+            val formattedMessage = format(message, humanReadableDate(Instant.now()), type)
+            writer.write(formattedMessage)
+            writer.close()
+        } catch (e: Exception) {
+            logger.error("Failed to write message to reach-hover log: $message", e)
+        }
+    }
+
+    private fun format(message: String, time: String, type: EventType): String {
+        return "$time - [$type] - $message\n"
+    }
+}
+
+enum class EventType {
+    TASK_START,
+    TASK_FINISH,
+    STANDARD_DATAFLOW_INVOKED,
+    REACH_HOVER_INVOKED,
+    FILE_OPEN,
+    FILE_CLOSED,
+}

--- a/src/main/kotlin/com/github/jyoo980/reachhover/analytics/ReachHoverAnalyticsService.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/analytics/ReachHoverAnalyticsService.kt
@@ -7,7 +7,6 @@ import com.github.jyoo980.reachhover.analytics.AnalyticsValues.reachHoverForward
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ex.AnActionListener
 import com.intellij.openapi.actionSystem.impl.ActionMenuItem
-import com.intellij.openapi.diagnostic.Logger
 import java.awt.AWTEvent
 import java.awt.Toolkit
 import java.awt.event.AWTEventListener
@@ -16,7 +15,6 @@ import javax.swing.JButton
 
 class ReachHoverAnalyticsService : AWTEventListener, AnActionListener, Disposable {
 
-    private val logger: Logger = Logger.getInstance(ReachHoverAnalyticsService::class.java)
     private var numTimesDataflowInvoked = 0
     private var numTimesReachHoverInvoked = 0
     private var prevActionChain: MutableList<AWTEvent> = mutableListOf()
@@ -49,8 +47,9 @@ class ReachHoverAnalyticsService : AWTEventListener, AnActionListener, Disposabl
             } else if (isOkButtonClicked(e)) {
                 if (prevActionChain.any(::isDataflowAnalysisEvent)) {
                     numTimesDataflowInvoked++
-                    logger.info(
-                        "==== ReachHoverAnalytics: Dataflow Analysis invoked: $numTimesDataflowInvoked time(s) ===="
+                    LogWriter.write(
+                        "Dataflow Analysis invoked: $numTimesDataflowInvoked time(s)",
+                        EventType.STANDARD_DATAFLOW_INVOKED
                     )
                     prevActionChain.clear()
                 }
@@ -70,8 +69,9 @@ class ReachHoverAnalyticsService : AWTEventListener, AnActionListener, Disposabl
         val isMousePressed = mouseEvent?.let { it.id == MouseEvent.MOUSE_PRESSED } ?: false
         if (isReachHoverEvent(e) && isMousePressed) {
             numTimesReachHoverInvoked++
-            logger.info(
-                "==== ReachHoverAnalytics: ReachHover invoked: $numTimesReachHoverInvoked time(s) ===="
+            LogWriter.write(
+                "ReachHover invoked: $numTimesReachHoverInvoked time(s)",
+                EventType.REACH_HOVER_INVOKED
             )
         }
     }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/analytics/TimeUtil.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/analytics/TimeUtil.kt
@@ -1,0 +1,14 @@
+package com.github.jyoo980.reachhover.analytics
+
+import java.sql.Date
+import java.sql.Timestamp
+import java.time.Instant
+
+interface TimeUtil {
+
+    fun humanReadableDate(ms: Instant): String {
+        val currentTimestamp = Timestamp(ms.toEpochMilli())
+        val date = Date(currentTimestamp.time)
+        return date.toString()
+    }
+}


### PR DESCRIPTION
  * Now adding `reach-hover` logs to a separate file.
  * Should be better for end-users because they won't have to delete any logs
    that don't belong to the plugin.