### PR TITLE
Improving notification performance

### DIFF
--- a/src/main/kotlin/com/github/jyoo980/reachhover/listeners/EditorHoverListener.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/listeners/EditorHoverListener.kt
@@ -29,7 +29,9 @@ internal class EditorHoverListener : EditorMouseMotionListener {
         val isDumbModeActive = dumbService?.isDumb ?: true
         if (isDumbModeActive) {
             e.editor.project?.let {
-                NotificationService.showNotification(it, MyBundle.message("dumbModeMessage"))
+                if (!NotificationService.isNotReadyWarningActive(it)) {
+                    NotificationService.showNotification(it, MyBundle.message("dumbModeMessage"))
+                }
             }
         } else {
             val actionStartTimeMs = System.currentTimeMillis()

--- a/src/main/kotlin/com/github/jyoo980/reachhover/services/NotificationService.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/services/NotificationService.kt
@@ -15,7 +15,6 @@ object NotificationService {
         NotificationGroupManager.getInstance().getNotificationGroup(groupId)
 
     fun showNotification(project: Project, message: String) {
-        expireNotifications(project)
         val notification =
             notificationGroupManager
                 .createNotification(message, NotificationType.INFORMATION)
@@ -24,10 +23,10 @@ object NotificationService {
         notification.notify(project)
     }
 
-    private fun expireNotifications(project: Project) {
+    fun isNotReadyWarningActive(project: Project): Boolean {
         val notifications =
             NotificationsManager.getNotificationsManager()
                 .getNotificationsOfType(Notification::class.java, project)
-        notifications.filter { it.groupId == groupId }.forEach { it.expire() }
+        return notifications.any { it.content == MyBundle.message("dumbModeMessage") }
     }
 }


### PR DESCRIPTION
Previously, we were issuing a notification every time the user invoked
`reach-hover` code when IntelliJ was running background tasks.

This is incredibly inefficient due to the high sample rate at which listeners
poll for events.

We now only issue `reach-hover` "not ready" warnings when the previous
notification has been expired.