### PR TITLE
Applying lint fixes suggested by Qodana

### DIFF
--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPanel.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ReachabilityPanel.kt
@@ -262,7 +262,7 @@ abstract class ReachabilityPanel(
 
     private val selectedUsageInfos: List<UsageInfo>?
         get() =
-            myTree.selectionPaths?.let { it ->
+            myTree.selectionPaths?.let {
                 it.mapNotNull { path ->
                     val sliceNode = fromPath(path)
                     sliceNode?.value?.usageInfo
@@ -286,12 +286,11 @@ abstract class ReachabilityPanel(
             for (path in paths) {
                 val lastPathComponent = path.lastPathComponent
                 if (lastPathComponent is DefaultMutableTreeNode) {
-                    val node = lastPathComponent
-                    val userObject = node.userObject
+                    val userObject = lastPathComponent.userObject
                     if (userObject is Navigatable) {
                         navigatables.add(userObject)
-                    } else if (node is Navigatable) {
-                        navigatables.add(node as Navigatable)
+                    } else if (lastPathComponent is Navigatable) {
+                        navigatables.add(lastPathComponent as Navigatable)
                     }
                 }
             }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/ui/ShowDocumentationButton.kt
@@ -56,6 +56,6 @@ class ShowDocumentationButton(private val element: PsiElement) {
         val docManager = DocumentationManager(element.project)
         val elements =
             docManager.findTargetElementAndContext(editor, offset, element.containingFile)
-        return elements?.let { it -> it.first to it.second }
+        return elements?.let { it.first to it.second }
     }
 }

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/MouseHoverUtil.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/MouseHoverUtil.kt
@@ -32,7 +32,7 @@ object MouseHoverUtil {
      */
     fun elementAtOffset(project: Project, editor: Editor, offset: Int): PsiElement? {
         val optFile = PsiDocumentManagerImpl.getInstance(project).getPsiFile(editor.document)
-        return optFile?.let { it ->
+        return optFile?.let {
             var element = it.findElementAt(offset)
             if (element == null && offset == it.textLength) {
                 element = it.findElementAt(offset - 1)

--- a/src/main/kotlin/com/github/jyoo980/reachhover/util/UAstExtension.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/util/UAstExtension.kt
@@ -22,7 +22,7 @@ fun UElement.isNonLiteralMethodArg(): Boolean {
     return parents
         .indexOfFirst { it is UAnonymousClass || it is ULambdaExpression }
         .takeIf { it >= 0 }
-        ?.let { it -> locationOfCallExpr < it }
+        ?.let { locationOfCallExpr < it }
         ?: arguments?.mapNotNull { it.tryResolveNamed()?.name }?.contains(nameOfElement) ?: false
 }
 


### PR DESCRIPTION
These are non-functional changes, but result in code that better follows standard Kotlin style. I'm not sure why they weren't picked up earlier in the cycle. I suspect that there was an IDE update that made these suggestions more visible. Some changes include:

  * Inlining variables that are used just once.
  * Removing an unnecessary `it` from lambda expressions.