### PR TITLE
Updating IntelliJ SDK and Kotlin SDK

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.6.10"
+    id("org.jetbrains.kotlin.jvm") version "1.8.0"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.12.0"
+    id("org.jetbrains.intellij") version "1.13.3"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // Gradle Qodana Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,24 +4,24 @@
 pluginGroup = com.github.jyoo980.reachhover
 pluginName = reach-hover
 # SemVer format -> https://semver.org
-pluginVersion = 1.4.0
+pluginVersion = 1.5.0
 
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 213
-pluginUntilBuild = 223
+pluginSinceBuild = 231
+pluginUntilBuild = 231.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.2
+platformVersion = 2023.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 11
+javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 7.4


### PR DESCRIPTION
ReachHover still works, but the warnings regarding the `AbstractTreeBuilder` are more frequent. Will need to find a workaround or move the class into the actual plugin source itself.