### PR TITLE
Removing unused code

### DIFF
--- a/src/main/kotlin/com/github/jyoo980/reachhover/actions/ShowReachabilityElementsAction.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/actions/ShowReachabilityElementsAction.kt
@@ -75,8 +75,6 @@ class ShowReachabilityElementsAction {
                 .addUserData(updateProcessor)
                 .setCancelOnWindowDeactivation(false)
                 .setCancelOnOtherWindowOpen(false)
-                //                .setCancelButton(IconButton("Close", IconManager.startTaskIcon,
-                // null)) // doesn't appear to work
                 .setTitle(questionText)
                 .setTitleIcon(IconManager.reachabilityIcon.let(::ActiveIcon))
                 .setDimensionServiceKey(

--- a/src/main/kotlin/com/github/jyoo980/reachhover/model/SliceTreeBuilder.kt
+++ b/src/main/kotlin/com/github/jyoo980/reachhover/model/SliceTreeBuilder.kt
@@ -42,18 +42,6 @@ class SliceTreeBuilder(
 
     override fun isAutoExpandNode(nodeDescriptor: NodeDescriptor<*>?): Boolean = false
 
-    fun switchToGroupedByLeavesNodes() {
-        val provider = getRootSliceNode().provider ?: return
-        analysisInProgress = true
-        provider.startAnalyzeLeafValues(treeStructure) { analysisInProgress = false }
-    }
-
-    fun switchToLeafNulls() {
-        val provider = getRootSliceNode().provider ?: return
-        analysisInProgress = true
-        provider.startAnalyzeNullness(treeStructure) { analysisInProgress = false }
-    }
-
     override fun createProgressIndicator(): ProgressIndicator? {
         return ProgressIndicatorBase(true)
     }


### PR DESCRIPTION
This commit removes unused/dead code that is not necessary for the plugin to work.

Specifically, this removes:

  * `SliceTreeBuilder#switchToGroupedByLeavesNodes`
  * `SliceTreeBuilder#switchToLeafNulls`

And some previously commented-out code in `ShowReachabilityElementsAction.kt`